### PR TITLE
Add circle background behind radar chart icons

### DIFF
--- a/src/components/IconLabelLayer.tsx
+++ b/src/components/IconLabelLayer.tsx
@@ -75,7 +75,23 @@ export default function IconLabelLayer({
               padding: '6px 12px',
               boxSizing: 'border-box',
             }}>
-              <img src={s.icon} alt={s.label} style={{ width: iconSize, height: iconSize }} />
+              <div
+                style={{
+                  backgroundColor: '#F6E2CA',
+                  borderRadius: '50%',
+                  width: iconSize * 1.4,
+                  height: iconSize * 1.4,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <img
+                  src={s.icon}
+                  alt={s.label}
+                  style={{ width: iconSize, height: iconSize }}
+                />
+              </div>
               <div style={{
                 marginTop: 2,
                 overflowWrap: 'break-word',


### PR DESCRIPTION
## Summary
- wrap each icon in a circle background
- circle uses color `#F6E2CA`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686585099c08832988ded0ed3d9d37cd